### PR TITLE
feat: replace grid miasma with drifting fog banks

### DIFF
--- a/core/game.js
+++ b/core/game.js
@@ -254,19 +254,18 @@ function draw() {
   ctx.fillStyle = "#0c0b10";
   ctx.fillRect(0, 0, w, h);
 
-if (state.activeWeapon === "beam") {
-  getBeamGeom(state, cx, cy);
-  if (!state.paused && !state.gameOver) {
-    clearWithBeam(state, cx, cy);
+  if (state.activeWeapon === "beam") {
+    getBeamGeom(state, cx, cy);
+    if (!state.paused && !state.gameOver) {
+      clearWithBeam(state, cx, cy);
+    }
   }
-}
 
-
-drawObstacles(ctx, state, cx, cy); // draw terrain first
-drawEnemies(ctx, state, cx, cy);
-drawPickups(ctx, state, cx, cy);
-drawMiasma(ctx, state, cx, cy, w, h);
-drawWorldBorder(ctx, state, cx, cy);
+  drawObstacles(ctx, state, cx, cy); // draw terrain first
+  drawEnemies(ctx, state, cx, cy);
+  drawPickups(ctx, state, cx, cy);
+  drawMiasma(state, ctx);
+  drawWorldBorder(ctx, state, cx, cy);
 if (state.activeWeapon === "beam") {
   drawBeam(ctx, state, cx, cy);
 } else if (state.activeWeapon === "drill") {


### PR DESCRIPTION
## Summary
- replace tile-based miasma with weather-like fog banks that drift with wind
- add wind shift logic, respawn banks upwind, and expose density query `isDenseFogAt`
- update game rendering to use new `drawMiasma(state, ctx)` signature and keep legacy helpers as no-ops

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ffb431fdc832dbe1fef9b4e046aa6