### PR TITLE
refactor: add scrap burst helper

### DIFF
--- a/systems/enemies.js
+++ b/systems/enemies.js
@@ -1,5 +1,5 @@
 // systems/enemies.js
-import { spawnPickup } from "./pickups.js";
+import { spawnPickup, spawnScrapBurst } from "./pickups.js";
 import { collideWithObstacles } from "./world.js";
 import { getDrillTriangleWorld } from "./drill.js";
 
@@ -183,13 +183,9 @@ export function updateEnemies(state, dt) {
     // Death & drops
     if (m.hp <= 0) {
       if (m.type === "fast") {
-        for (let k = 0; k < 5; k++) {
-          spawnPickup(state, m.x + Math.random() * 10 - 5, m.y + Math.random() * 10 - 5, "scrap");
-        }
+        spawnScrapBurst(state, m.x, m.y, 5);
       } else if (m.type === "tank") {
-        for (let k = 0; k < 5; k++) {
-          spawnPickup(state, m.x + Math.random() * 10 - 5, m.y + Math.random() * 10 - 5, "scrap");
-        }
+        spawnScrapBurst(state, m.x, m.y, 5);
       } else {
         if (Math.random() < 0.1) {
           spawnPickup(state, m.x, m.y, "health");

--- a/systems/pickups.js
+++ b/systems/pickups.js
@@ -3,6 +3,14 @@ export function spawnPickup(state, x, y, type = "scrap") {
   state.pickups.push({ x, y, type, r: 6 });
 }
 
+export function spawnScrapBurst(state, x, y, count) {
+  for (let i = 0; i < count; i++) {
+    const nx = x + Math.random() * 10 - 5;
+    const ny = y + Math.random() * 10 - 5;
+    spawnPickup(state, nx, ny, "scrap");
+  }
+}
+
 export function updatePickups(state, dt) {
   const px = state.camera.x;
   const py = state.camera.y;


### PR DESCRIPTION
## Summary
- add `spawnScrapBurst` helper to spawn multiple scrap pickups
- reuse helper for fast and tank enemy drop logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ea44a2b4832da7196df5ca6a7121