### PR TITLE
Refactor state management into GameState

### DIFF
--- a/core/state.js
+++ b/core/state.js
@@ -1,0 +1,181 @@
+// core/state.js
+// Global game state definitions and factory.
+
+/**
+ * @typedef {{x: number, y: number}} Vec2
+ */
+
+/**
+ * @typedef {Object} BeamState
+ * @property {number} t
+ * @property {number} step
+ * @property {number} tNoBeamEnd
+ * @property {number} tBubbleEnd
+ * @property {number} tConeEnd
+ * @property {number} bubbleRMin
+ * @property {number} bubbleRMax
+ * @property {number} coneHalfArcWide
+ * @property {number} coneHalfArcNarrow
+ * @property {number} laserMinHalfArc
+ * @property {number} baseRange
+ * @property {number} laserRange
+ * @property {number} bumpRange
+ * @property {number} laserCoreWidth
+ * @property {number} laserOutlineMult
+ * @property {number} laserTipRadius
+ * @property {string} mode
+ * @property {number} range
+ * @property {number} halfArc
+ * @property {number} angle
+ * @property {number} radius
+ * @property {{main0:string,main1:string,main2:string,laser0:string,laser1:string,laser2:string,tip:string,core:string,halo:string}} color
+ */
+
+/**
+ * @typedef {Object} MiasmaState
+ * @property {number} tile
+ * @property {number} halfCols
+ * @property {number} halfRows
+ * @property {number} cols
+ * @property {number} rows
+ * @property {number} stride
+ * @property {number} size
+ * @property {Uint8Array} strength
+ * @property {Uint8Array} strengthNext
+ * @property {number} regrowDelay
+ * @property {number} baseChance
+ * @property {number} tickHz
+ * @property {Float32Array} lastCleared
+ * @property {number} _accum
+ * @property {number} laserMinThicknessTiles
+ * @property {number} laserFanCount
+ * @property {number} laserFanMinDeg
+ * @property {number} dps
+ */
+
+/**
+ * @typedef {Object} EnemyProjectile
+ * @property {number} x
+ * @property {number} y
+ * @property {number} dx
+ * @property {number} dy
+ * @property {number} w
+ * @property {number} h
+ * @property {number} speed
+ */
+
+/**
+ * @typedef {Object} EnemyState
+ * @property {Array<Object>} list
+ * @property {number} max
+ * @property {number} worldW
+ * @property {number} worldH
+ * @property {number} speed
+ * @property {number} detectRadius
+ * @property {number} size
+ * @property {number} baseHP
+ * @property {number} laserDPS
+ * @property {number} flashTime
+ * @property {number} contactDPS
+ * @property {number} spawnEvery
+ * @property {number} safeDistInitial
+ * @property {number} safeDistTrickle
+ * @property {number} tankBulletSpeed
+ * @property {number} tankBulletCooldown
+ * @property {number} tankBulletDamage
+ * @property {number} tankBulletWidth
+ * @property {number} tankBulletHeight
+ * @property {number} spawnTimer
+ */
+
+/**
+ * @typedef {Object} WorldState
+ * @property {number} minX
+ * @property {number} maxX
+ * @property {number} minY
+ * @property {number} maxY
+ * @property {number} borderThickness
+ * @property {string} borderColor
+ */
+
+/**
+ * @typedef {Object} DrillState
+ * @property {number} length
+ * @property {number} width
+ * @property {number} offset
+ * @property {number} dps
+ * @property {string} fill
+ * @property {string} stroke
+ * @property {string} capFill
+ * @property {string} capStroke
+ * @property {number} playerRadius
+ */
+
+/**
+ * @typedef {Object} Pickup
+ * @property {number} x
+ * @property {number} y
+ * @property {string} type
+ * @property {number} r
+ */
+
+/**
+ * @typedef {Object} GameState
+ * @property {number} time
+ * @property {number} dt
+ * @property {Vec2} mouse
+ * @property {Vec2} pendingMouse
+ * @property {Vec2} camera
+ * @property {{r:number}} player
+ * @property {Set<string>} keys
+ * @property {number} health
+ * @property {number} maxHealth
+ * @property {boolean} gameOver
+ * @property {number} scrap
+ * @property {Array<Pickup>} pickups
+ * @property {number} damageFlash
+ * @property {boolean} paused
+ * @property {boolean} win
+ * @property {number} maxScrap
+ * @property {number} laserEnergy
+ * @property {number} maxLaserEnergy
+ * @property {"beam"|"drill"} activeWeapon
+ * @property {BeamState} [beam]
+ * @property {MiasmaState} [miasma]
+ * @property {EnemyState} [enemies]
+ * @property {WorldState} [world]
+ * @property {Uint8Array} [obstacleGrid]
+ * @property {DrillState} [drill]
+ * @property {{show?:boolean,perf?:any}} [dev]
+ * @property {Array<EnemyProjectile>} enemyProjectiles
+ */
+
+/**
+ * Create a new blank game state.
+ * @returns {GameState}
+ */
+export function createGameState() {
+  return {
+    time: 0, dt: 0,
+    mouse: { x: 0, y: 0 },
+    pendingMouse: { x: 0, y: 0 },
+    camera: { x: 0, y: 0 },
+    player: { r: 18 },
+    keys: new Set(),
+    health: 100,
+    maxHealth: 100,
+    gameOver: false,
+    scrap: 0,
+    pickups: [],
+    damageFlash: 0,
+    paused: false,
+    win: false,
+    maxScrap: 0,
+    laserEnergy: 0,
+    maxLaserEnergy: 0,
+    activeWeapon: "beam",
+    enemyProjectiles: [],
+  };
+}
+
+export {}; // so this file is a module

--- a/systems/beam.js
+++ b/systems/beam.js
@@ -1,7 +1,9 @@
 // systems/beam.js — half-size beam with distinct laser core
+/** @typedef {import('../core/state.js').BeamState} BeamState */
 
-export function initBeam(state, opts = {}) {
-  state.beam = {
+export function initBeam(opts = {}) {
+  /** @type {BeamState} */
+  const beam = {
     // control
     t: clamp(opts.startT ?? 0.7, 0, 1),
     step: opts.wheelStep ?? 0.05,
@@ -50,18 +52,17 @@ export function initBeam(state, opts = {}) {
       halo:   'rgba(255, 220, 120, 0.35)'
     }
   };
+  return beam;
 }
 
-export function onWheelAdjust(state, deltaY) {
-  const b = state.beam;
+export function onWheelAdjust(b, deltaY) {
   const dir = deltaY > 0 ? -1 : 1; // wheel down => laser, wheel up => off
   b.t = clamp(b.t + dir * b.step, 0, 1);
 }
 
-export function getBeamGeom(state, cx, cy) {
-  const b = state.beam;
+export function getBeamGeom(b, mouse, cx, cy) {
   const t = b.t;
-  const ang = Math.atan2(state.mouse.y - cy, state.mouse.x - cx);
+  const ang = Math.atan2(mouse.y - cy, mouse.x - cx);
 
   if (t <= b.tNoBeamEnd) {
     return Object.assign(b, { mode: 'none', range: 0, halfArc: 0, angle: ang, radius: 0 });
@@ -85,8 +86,7 @@ export function getBeamGeom(state, cx, cy) {
   return Object.assign(b, { mode: 'laser', range: b.laserRange, halfArc, angle: ang, radius: 0 });
 }
 
-export function drawBeam(ctx, state, cx, cy) {
-  const b = state.beam;
+export function drawBeam(ctx, b, cx, cy) {
   if (b.mode === 'none') return;
   if (b.mode === 'bubble') return drawCircle(ctx, cx, cy, b.radius, b);
   if (b.mode === 'cone')   return drawCone(ctx, cx, cy, b.halfArc, b.range, b);

--- a/systems/drill.js
+++ b/systems/drill.js
@@ -1,8 +1,10 @@
 // systems/drill.js
+/** @typedef {import('../core/state.js').DrillState} DrillState */
 
-export function initDrill(state, opts = {}) {
-  const r = state.player?.r ?? 18;
-  state.drill = {
+export function initDrill(player, opts = {}) {
+  const r = player?.r ?? 18;
+  /** @type {DrillState} */
+  const drill = {
     length: opts.length ?? 55,                       // short & stout
     width:  opts.width  ?? Math.min(40, r * 1.8),    // chunky base
     offset: opts.offset ?? 0,
@@ -16,15 +18,16 @@ export function initDrill(state, opts = {}) {
     capStroke: opts.capStroke ?? "#374151",          // base cap outline
     playerRadius: r
   };
+  return drill;
 }
 
-export function drawDrill(ctx, state, cx, cy) {
-  if (!state.drill || state.activeWeapon !== "drill") return;
+export function drawDrill(ctx, drill, mouse, activeWeapon, cx, cy) {
+  if (!drill || activeWeapon !== "drill") return;
 
-  const { length, width, offset, fill, stroke, capFill, capStroke, playerRadius } = state.drill;
+  const { length, width, offset, fill, stroke, capFill, capStroke, playerRadius } = drill;
 
   // Aim in SCREEN space
-  const ang = Math.atan2(state.mouse.y - cy, state.mouse.x - cx);
+  const ang = Math.atan2(mouse.y - cy, mouse.x - cx);
 
   // Keep base inside derelict circle
   const safeOffset = Math.max(offset, playerRadius - (width / 2) - 1);
@@ -77,8 +80,8 @@ export function drawDrill(ctx, state, cx, cy) {
  * Returns the drill triangle in WORLD coordinates + its AABB.
  * Used for obstacle carving and enemy damage checks.
  */
-export function getDrillTriangleWorld(state) {
-  const { length, width, offset, playerRadius } = state.drill;
+export function getDrillTriangleWorld(drill, camera, mouse) {
+  const { length, width, offset, playerRadius } = drill;
 
   // Hitbox tuning (visual helpers)
   const hitboxLengthMult = 1.15; // >1 = longer reach than visual
@@ -87,12 +90,12 @@ export function getDrillTriangleWorld(state) {
   const halfW = (width * hitboxWidthMult) * 0.5;
 
   // Player world position
-  const px = state.camera.x, py = state.camera.y;
+  const px = camera.x, py = camera.y;
 
   // Use window size for screen center (drill aims in screen space)
   const cx = (typeof window !== "undefined" ? window.innerWidth  * 0.5 : 0);
   const cy = (typeof window !== "undefined" ? window.innerHeight * 0.5 : 0);
-  const ang = Math.atan2(state.mouse.y - cy, state.mouse.x - cx);
+  const ang = Math.atan2(mouse.y - cy, mouse.x - cx);
 
   // Keep base inside circle
   const safeOffset = Math.max(offset, playerRadius - halfW - 1);

--- a/systems/pickups.js
+++ b/systems/pickups.js
@@ -1,15 +1,17 @@
 // systems/pickups.js
-export function spawnPickup(state, x, y, type = "scrap") {
-  state.pickups.push({ x, y, type, r: 6 });
+/** @typedef {import('../core/state.js').Pickup} Pickup */
+
+export function spawnPickup(pickups, x, y, type = "scrap") {
+  pickups.push({ x, y, type, r: 6 });
 }
 
-export function updatePickups(state, dt) {
-  const px = state.camera.x;
-  const py = state.camera.y;
-  const pr = state.player.r;
+export function updatePickups(pickups, camera, player, state, dt) {
+  const px = camera.x;
+  const py = camera.y;
+  const pr = player.r;
 
-  for (let i = state.pickups.length - 1; i >= 0; i--) {
-    const p = state.pickups[i];
+  for (let i = pickups.length - 1; i >= 0; i--) {
+    const p = pickups[i];
     const dist = Math.hypot(px - p.x, py - p.y);
     if (dist <= pr + p.r) {
       if (p.type === "scrap") {
@@ -17,16 +19,16 @@ export function updatePickups(state, dt) {
       } else if (p.type === "health") {
         state.health = Math.min(state.maxHealth, state.health + 20);
       }
-      state.pickups.splice(i, 1);
+      pickups.splice(i, 1);
     }
   }
 }
 
-export function drawPickups(ctx, state, cx, cy) {
-  const px = state.camera.x;
-  const py = state.camera.y;
+export function drawPickups(ctx, pickups, camera, cx, cy) {
+  const px = camera.x;
+  const py = camera.y;
 
-  for (const p of state.pickups) {
+  for (const p of pickups) {
     const sx = p.x - px + cx;
     const sy = p.y - py + cy;
     ctx.beginPath();

--- a/ui/devhud.js
+++ b/ui/devhud.js
@@ -1,7 +1,9 @@
 // ui/devhud.js
 // Ultra-light Dev HUD: FPS + dt only, drawn at top-right.
 // Toggle with "P" (hooked up in core/game.js).
+/** @typedef {import('../core/state.js').GameState} GameState */
 
+/** @param {GameState} state */
 export function initDevHUD(state) {
   state.dev = state.dev || {};
   state.dev.show = state.dev.show ?? false; // starts hidden
@@ -14,11 +16,13 @@ export function initDevHUD(state) {
   };
 }
 
+/** @param {GameState} state */
 export function toggleDevHUD(state) {
   state.dev = state.dev || {};
   state.dev.show = !state.dev.show;
 }
 
+/** @param {GameState} state */
 export function updateDevHUD(state, dt) {
   const p = state.dev?.perf;
   if (!p) return;
@@ -34,6 +38,7 @@ export function updateDevHUD(state, dt) {
   }
 }
 
+/** @param {GameState} state */
 export function drawDevHUD(ctx, state) {
   const dev = state?.dev;
   if (!dev?.show) return;

--- a/ui/hud.js
+++ b/ui/hud.js
@@ -1,5 +1,7 @@
+/** @typedef {import('../core/state.js').GameState} GameState */
 var els = null;
 
+/** @param {GameState} state */
 export function initHUD(state, opts = {}) {
   var root = document.getElementById('hud-root');
   if (!root) {
@@ -45,6 +47,7 @@ export function initHUD(state, opts = {}) {
   updateHUD(state);
 }
 
+/** @param {GameState} state */
 export function updateHUD(state) {
   if (!els) return;
 


### PR DESCRIPTION
## Summary
- centralize global data with a typed `GameState` and subsystem definitions
- pass explicit state slices to systems to reduce hidden coupling
- update game loop and systems to use the new state structures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a10f9d780c832db6781c09645b6c7b