### PR TITLE
Integrate isometric coordinate conversions

### DIFF
--- a/core/game.js
+++ b/core/game.js
@@ -1,5 +1,6 @@
 // core/game.js
 import { config } from "../core/config.js";
+import { worldToScreenIso, screenToWorldIso } from "./iso.js";
 import { beam, miasma, enemies, pickups, world, drill } from "../systems/index.js";
 import { hud, devhud } from "../ui/index.js";
 import { createGameState } from "./state.js";
@@ -9,6 +10,9 @@ import { createGameState } from "./state.js";
 
 const canvas = document.getElementById("game");
 const ctx = canvas.getContext("2d", { alpha: false });
+
+config.game.tileW = 32;
+config.game.tileH = 16;
 
 const state = createGameState();
 state.maxScrap = config.game.winScrap;

--- a/core/iso.js
+++ b/core/iso.js
@@ -1,0 +1,23 @@
+import { config } from "./config.js";
+
+export function worldToScreenIso(x, y, camera) {
+  const w = config.game.tileW;
+  const h = config.game.tileH;
+  const wx = x - camera.x;
+  const wy = y - camera.y;
+  return {
+    x: (wx - wy) * w,
+    y: (wx + wy) * h
+  };
+}
+
+export function screenToWorldIso(sx, sy, camera) {
+  const w = config.game.tileW;
+  const h = config.game.tileH;
+  const wx = 0.5 * (sx / w + sy / h);
+  const wy = 0.5 * (sy / h - sx / w);
+  return {
+    x: wx + camera.x,
+    y: wy + camera.y
+  };
+}

--- a/systems/enemies.js
+++ b/systems/enemies.js
@@ -2,6 +2,7 @@
 import { spawnPickup } from "./pickups.js";
 import { collideWithObstacles, pointInTriangle } from "./world.js";
 import { getDrillTriangleWorld } from "./drill.js";
+import { worldToScreenIso } from "../core/iso.js";
 /** @typedef {import('../core/state.js').GameState} GameState */
 
 export function initEnemies(miasma, opts = {}) {
@@ -209,13 +210,11 @@ export function updateEnemies(state, dt) {
 /** @param {GameState} state */
 export function drawEnemies(ctx, state, cx, cy) {
   const cfg = state.enemies;
-  const px = state.camera.x, py = state.camera.y;
 
   for (const m of cfg.list) {
-    const sx = m.x - px + cx;
-    const sy = m.y - py + cy;
+    const { x: dx, y: dy } = worldToScreenIso(m.x, m.y, state.camera);
     ctx.beginPath();
-    ctx.arc(sx, sy, m.r, 0, Math.PI * 2);
+    ctx.arc(cx + dx, cy + dy, m.r, 0, Math.PI * 2);
 
     if (m.type === "fast") {
       ctx.fillStyle = m.flash > 0 ? `rgba(255,255,255,${m.flash / cfg.flashTime})` : 'rgba(50,50,200,0.9)';
@@ -280,14 +279,10 @@ function updateEnemyProjectiles(state, dt) {
 }
 
 function drawEnemyProjectiles(ctx, state, cx, cy) {
-  const px = state.camera.x;
-  const py = state.camera.y;
-
   for (const p of state.enemyProjectiles) {
-    const sx = p.x - px + cx;
-    const sy = p.y - py + cy;
+    const { x: dx, y: dy } = worldToScreenIso(p.x, p.y, state.camera);
     ctx.save();
-    ctx.translate(sx, sy);
+    ctx.translate(cx + dx, cy + dy);
     ctx.rotate(Math.atan2(p.dy, p.dx));
 
     ctx.fillStyle = 'rgba(255,0,0,0.9)';

--- a/systems/miasma.js
+++ b/systems/miasma.js
@@ -6,6 +6,7 @@
  * @typedef {import('../core/state.js').MiasmaState} MiasmaState
  * @typedef {import('../core/state.js').BeamState} BeamState
  */
+import { worldToScreenIso } from "../core/iso.js";
 
 export function initMiasma(opts = {}) {
   const halfCols = Math.floor((opts.cols ?? 400) / 2);
@@ -77,13 +78,13 @@ export function drawMiasma(ctx, s, camera, cx, cy, w, h) {
   ctx.fillStyle = 'rgba(120, 60, 160, 0.50)';
   ctx.beginPath();
 
-  // compute first screen row start, then increment by tile size
-  let sy = Math.floor(minGY * t - camera.y + cy);
-  for (let gy = minGY; gy < maxGY; gy++, sy += t) {
-    let sx = Math.floor(minGX * t - camera.x + cx);
-    for (let gx = minGX; gx < maxGX; gx++, sx += t) {
+  for (let gy = minGY; gy < maxGY; gy++) {
+    for (let gx = minGX; gx < maxGX; gx++) {
       if (s.strength[idx(s, gx, gy)] === 1) {
-        ctx.rect(sx, sy, t, t);
+        const wx = gx * t;
+        const wy = gy * t;
+        const { x: dx, y: dy } = worldToScreenIso(wx, wy, camera);
+        ctx.rect(cx + dx, cy + dy, t, t);
       }
     }
   }

--- a/systems/pickups.js
+++ b/systems/pickups.js
@@ -1,5 +1,6 @@
 // systems/pickups.js
 /** @typedef {import('../core/state.js').Pickup} Pickup */
+import { worldToScreenIso } from "../core/iso.js";
 
 export function spawnPickup(pickups, x, y, type = "scrap") {
   pickups.push({ x, y, type, r: 6 });
@@ -25,14 +26,10 @@ export function updatePickups(pickups, camera, player, state, dt) {
 }
 
 export function drawPickups(ctx, pickups, camera, cx, cy) {
-  const px = camera.x;
-  const py = camera.y;
-
   for (const p of pickups) {
-    const sx = p.x - px + cx;
-    const sy = p.y - py + cy;
+    const { x: dx, y: dy } = worldToScreenIso(p.x, p.y, camera);
     ctx.beginPath();
-    ctx.arc(sx, sy, p.r, 0, Math.PI * 2);
+    ctx.arc(cx + dx, cy + dy, p.r, 0, Math.PI * 2);
     ctx.fillStyle = (p.type === "scrap") ? "#ff0" : "#0f0";
     ctx.fill();
     ctx.strokeStyle = "#fff";

--- a/systems/world.js
+++ b/systems/world.js
@@ -1,6 +1,7 @@
 // systems/world.js
 /** @typedef {import('../core/state.js').MiasmaState} MiasmaState */
 /** @typedef {import('../core/state.js').WorldState} WorldState */
+import { worldToScreenIso } from "../core/iso.js";
 
 export function initWorld(miasma, player, opts = {}) {
   const t = miasma.tile;
@@ -115,27 +116,31 @@ export function drawWorldBorder(ctx, world, camera, cx, cy) {
   ctx.save();
   ctx.fillStyle = color;
 
+  const top = worldToScreenIso(world.minX - thickness, world.minY - thickness, camera);
   ctx.fillRect(
-    world.minX - camera.x + cx - thickness,
-    world.minY - thickness - camera.y + cy,
+    cx + top.x,
+    cy + top.y,
     (world.maxX - world.minX) + thickness * 2,
     thickness
   );
+  const bottom = worldToScreenIso(world.minX - thickness, world.maxY, camera);
   ctx.fillRect(
-    world.minX - camera.x + cx - thickness,
-    world.maxY - camera.y + cy,
+    cx + bottom.x,
+    cy + bottom.y,
     (world.maxX - world.minX) + thickness * 2,
     thickness
   );
+  const left = worldToScreenIso(world.minX - thickness, world.minY, camera);
   ctx.fillRect(
-    world.minX - thickness - camera.x + cx,
-    world.minY - camera.y + cy,
+    cx + left.x,
+    cy + left.y,
     thickness,
     (world.maxY - world.minY)
   );
+  const right = worldToScreenIso(world.maxX, world.minY, camera);
   ctx.fillRect(
-    world.maxX - camera.x + cx,
-    world.minY - camera.y + cy,
+    cx + right.x,
+    cy + right.y,
     thickness,
     (world.maxY - world.minY)
   );
@@ -148,8 +153,6 @@ export function drawObstacles(ctx, miasma, obstacleGrid, camera, cx, cy) {
   const t = miasma.tile;
   const cols = miasma.cols;
   const rows = miasma.rows;
-  const px = camera.x;
-  const py = camera.y;
 
   ctx.save();
   ctx.fillStyle = "#444";
@@ -160,7 +163,8 @@ export function drawObstacles(ctx, miasma, obstacleGrid, camera, cx, cy) {
       if (obstacleGrid[idx] === 1) {
         const x = col * t - miasma.halfCols * t;
         const y = row * t - miasma.halfRows * t;
-        ctx.fillRect(x - px + cx, y - py + cy, t, t);
+        const { x: dx, y: dy } = worldToScreenIso(x, y, camera);
+        ctx.fillRect(cx + dx, cy + dy, t, t);
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `core/iso.js` with `worldToScreenIso` and `screenToWorldIso`
- set `tileW`/`tileH` config and import helpers in `core/game.js`
- replace manual camera translations in enemies, pickups, world, and miasma drawing routines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13b008438832da8cb6d335a019bd5