### PR TITLE
feat: introduce drifting wind system

### DIFF
--- a/core/game.js
+++ b/core/game.js
@@ -1,6 +1,6 @@
 // core/game.js
 import { config } from "../core/config.js";
-import { beam, miasma, enemies, pickups, world, drill } from "../systems/index.js";
+import { beam, miasma, enemies, pickups, world, drill, wind } from "../systems/index.js";
 import { hud, devhud } from "../ui/index.js";
 import { createGameState } from "./state.js";
 
@@ -14,6 +14,9 @@ ctx.imageSmoothingEnabled = false; // keeps pixels crisp (not required, but nice
 
 const state = createGameState();
 state.miasmaEnabled = true;
+state.wind.direction = wind.direction;
+state.wind.speed = wind.speed;
+state.wind.mode = wind.mode;
 state.maxScrap = config.game.winScrap;
 state.laserEnergy = state.maxLaserEnergy = config.game.maxLaserEnergy;
 state.drillHeat = 0;
@@ -99,6 +102,13 @@ window.addEventListener("keydown", (e) => {
 
 
 function startGame() {
+  wind.direction = 0;
+  wind.speed = 0;
+  wind.mode = 'steady';
+  state.wind.direction = 0;
+  state.wind.speed = 0;
+  state.wind.mode = 'steady';
+
   // base state
   state.miasmaEnabled = true;
   state.time = 0;
@@ -174,15 +184,16 @@ function update(dt) {
 
 
 // --- Drill carving using triangle hitbox ---
-if (state.activeWeapon === "drill" && state.drill && !state.drillOverheated) {
-  const tri = drill.getDrillTriangleWorld(state.drill, state.camera, state.mouse);
-  if (world.carveObstaclesWithDrillTri(state.miasma, state.obstacleGrid, tri, dt, 2)) {
-    state.drillDidHit = true;
+  if (state.activeWeapon === "drill" && state.drill && !state.drillOverheated) {
+    const tri = drill.getDrillTriangleWorld(state.drill, state.camera, state.mouse);
+    if (world.carveObstaclesWithDrillTri(state.miasma, state.obstacleGrid, tri, dt, 2)) {
+      state.drillDidHit = true;
+    }
   }
-}
-
-
-
+  wind.updateWind(dt);
+  state.wind.direction = wind.direction;
+  state.wind.speed = wind.speed;
+  state.wind.mode = wind.mode;
 
   if (state.miasmaEnabled) {
     miasma.updateMiasma(state.miasma, state.time, dt);

--- a/core/state.js
+++ b/core/state.js
@@ -120,6 +120,13 @@
  */
 
 /**
+ * @typedef {Object} WindState
+ * @property {number} direction
+ * @property {number} speed
+ * @property {string} mode
+ */
+
+/**
  * @typedef {Object} GameState
  * @property {number} time
  * @property {number} dt
@@ -145,6 +152,7 @@
  * @property {boolean} drillOverheated
  * @property {number} drillCoolTimer
  * @property {boolean} drillDidHit
+ * @property {WindState} wind
  * @property {BeamState} [beam]
  * @property {MiasmaState} [miasma]
  * @property {EnemyState} [enemies]
@@ -185,6 +193,7 @@ export function createGameState() {
     drillCoolTimer: 0,
     drillDidHit: false,
     enemyProjectiles: [],
+    wind: { direction: 0, speed: 0, mode: 'steady' },
   };
 }
 

--- a/systems/index.js
+++ b/systems/index.js
@@ -4,3 +4,4 @@ export * as enemies from "./enemies.js";
 export * as miasma from "./miasma.js";
 export * as pickups from "./pickups.js";
 export * as world from "./world.js";
+export * as wind from "./wind.js";

--- a/systems/wind.js
+++ b/systems/wind.js
@@ -1,0 +1,35 @@
+// systems/wind.js
+// Simple wind simulation with slow drift and occasional gusts.
+
+export let direction = 0; // radians
+export let speed = 0;     // arbitrary units
+export let mode = 'steady';
+
+let jumpTimer = randRange(5, 10);
+
+/**
+ * Update the global wind values.
+ * @param {number} dt
+ */
+export function updateWind(dt) {
+  // small random walk for gentle drifting
+  direction += randRange(-0.25, 0.25) * dt;
+  speed += randRange(-5, 5) * dt;
+  if (speed < 0) speed = 0;
+  direction = (direction + Math.PI * 2) % (Math.PI * 2);
+
+  jumpTimer -= dt;
+  if (jumpTimer <= 0) {
+    // big random jump (gust)
+    direction = Math.random() * Math.PI * 2;
+    speed = randRange(20, 80);
+    mode = 'gust';
+    jumpTimer = randRange(5, 10);
+  } else {
+    mode = 'steady';
+  }
+}
+
+function randRange(min, max) {
+  return Math.random() * (max - min) + min;
+}


### PR DESCRIPTION
## Summary
- add wind simulation with drifting direction and occasional gusts
- track wind in game state and reset on new runs
- update wind each frame before miasma handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d66151a8832d9621b14f9b0ce7f0