### PR TITLE
Replace miasma regrowth with wind-driven tiles

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -44,9 +44,6 @@ export const config = {
     tile: 5,
     cols: 450,
     rows: 450,
-    regrowDelay: 1.0,
-    baseChance: 0.20,
-    tickHz: 8,
 
     // Laser sweep tuning
     laserMinThicknessTiles: 2.0,

--- a/core/game.js
+++ b/core/game.js
@@ -185,7 +185,7 @@ if (state.activeWeapon === "drill" && state.drill && !state.drillOverheated) {
 
 
   if (state.miasmaEnabled) {
-    miasma.updateMiasma(state.miasma, state.time, dt);
+    miasma.updateMiasma(state.miasma, state.wind, dt);
   }
   enemies.updateEnemies(state, dt);
   pickups.updatePickups(state.pickups, state.camera, state.player, state, dt);

--- a/core/state.js
+++ b/core/state.js
@@ -38,20 +38,17 @@
  * @property {number} halfRows
  * @property {number} cols
  * @property {number} rows
- * @property {number} stride
- * @property {number} size
- * @property {Uint8Array} strength
- * @property {Uint8Array} strengthNext
- * @property {number} regrowDelay
- * @property {number} baseChance
- * @property {number} tickHz
- * @property {Float32Array} lastCleared
- * @property {number} _accum
+ * @property {Array<Array<boolean>>} tiles
+ * @property {number} originGX
+ * @property {number} originGY
+ * @property {number} _accumX
+ * @property {number} _accumY
  * @property {number} laserMinThicknessTiles
  * @property {number} laserFanCount
  * @property {number} laserFanMinDeg
  * @property {number} dps
- */
+ * @property {number} seed
+*/
 
 /**
  * @typedef {Object} EnemyProjectile
@@ -145,6 +142,7 @@
  * @property {boolean} drillOverheated
  * @property {number} drillCoolTimer
  * @property {boolean} drillDidHit
+ * @property {{direction:number,speed:number}} wind
  * @property {BeamState} [beam]
  * @property {MiasmaState} [miasma]
  * @property {EnemyState} [enemies]
@@ -185,6 +183,7 @@ export function createGameState() {
     drillCoolTimer: 0,
     drillDidHit: false,
     enemyProjectiles: [],
+    wind: { direction: 0, speed: 0 },
   };
 }
 


### PR DESCRIPTION
## Summary
- replace regrowth arrays with a 2D boolean tile grid and noise-based initialization
- shift miasma tiles by whole tiles according to wind direction and speed
- wire up wind state and remove unused regrowth config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1df4fa444832d9a49ae5dfdf2f365