### PR TITLE
Replace miasma regrowth with wind-driven grid

### DIFF
--- a/core/game.js
+++ b/core/game.js
@@ -138,7 +138,7 @@ function startGame() {
   state.pendingMouse.y = state.mouse.y;
 
   // world + systems (same order as first load)
-  state.miasma = miasma.initMiasma(config.miasma);                 // brand-new fog grid
+  state.miasma = miasma.init(config.miasma);                        // brand-new fog grid
   const wInit = world.initWorld(state.miasma, state.player, config.world); // world depends on miasma size
   state.world = wInit.world;
   state.obstacleGrid = wInit.obstacleGrid;
@@ -196,7 +196,7 @@ function update(dt) {
   state.wind.mode = wind.mode;
 
   if (state.miasmaEnabled) {
-    miasma.updateMiasma(state.miasma, state.time, dt);
+    miasma.update(state.miasma, dt);
   }
   enemies.updateEnemies(state, dt);
   pickups.updatePickups(state.pickups, state.camera, state.player, state, dt);
@@ -293,7 +293,7 @@ function draw() {
     beam.update(state.beam, state.mouse, cx, cy);
     if (state.miasmaEnabled && !state.paused && !state.gameOver) {
       // keep using the REAL camera for gameplay/clearing logic
-      miasma.clearWithBeam(state.miasma, state.beam, state.camera, state.time, cx, cy);
+      miasma.clearWithBeam(state.miasma, state.beam, state.camera, cx, cy);
     }
   }
 
@@ -303,7 +303,7 @@ function draw() {
   pickups.drawPickups(ctx, state.pickups, camDraw, cx, cy);  // now uses camDraw
 
   if (state.miasmaEnabled) {
-    miasma.drawMiasma(ctx, state.miasma, camDraw, cx, cy, w, h); // now uses camDraw
+    miasma.draw(ctx, state.miasma, camDraw, cx, cy, w, h); // now uses camDraw
   }
 
   world.drawWorldBorder(ctx, state.world, camDraw, cx, cy); // now uses camDraw

--- a/core/state.js
+++ b/core/state.js
@@ -40,13 +40,10 @@
  * @property {number} rows
  * @property {number} stride
  * @property {number} size
- * @property {Uint8Array} strength
- * @property {Uint8Array} strengthNext
- * @property {number} regrowDelay
- * @property {number} baseChance
- * @property {number} tickHz
- * @property {Float32Array} lastCleared
- * @property {number} _accum
+ * @property {Uint8Array} cells
+ * @property {number} spawnChance
+ * @property {number} _driftX
+ * @property {number} _driftY
  * @property {number} laserMinThicknessTiles
  * @property {number} laserFanCount
  * @property {number} laserFanMinDeg


### PR DESCRIPTION
## Summary
- Track miasma as a drifting boolean grid that shifts with wind
- Add spawn probability with jitter for upwind edge regeneration
- Expose `init`, `update`, and `draw` to conform to system API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e618add4832db757ecb92cab6973